### PR TITLE
Handle API Gateway deployments with terraform

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,6 +13,29 @@ A terraform project to deploy the get-hc-product lambda function to AWS and conf
 * Set values for the input variables defined in `input.tf`. Refer to the variables' descriptions in order to determine what they are used for. Help on setting input variables in terraform can be found [here](https://www.terraform.io/docs/configuration/variables.html#assigning-values-to-root-module-variables)
 * Set authentication to AWS, using either AWS CLI configuration file or environment variables - [help](https://www.terraform.io/docs/providers/aws/index.html#environment-variables)
 
+## AWS Api Gateway deployments
+
+AWS process of deploying changes to the API Gateway is as follows:
+
+1. Make changes to the gateway properties - resources, methods etc.
+2. Rollout the changes by creating a "deployment". This represent the API Gateway configuration at the time of the deployment creation.
+3. Point one or more stages to this deployment.
+
+The deployments are stored and so any stage can be pointed to any deployment as needed.
+
+To handle this process the terraform configuration uses the `api_deployments` and `prod_deployment_id` variables.
+
+`api_deployments` - a list of description of deployments. Every time an item is added to the list a new deployment is created. Removing items from the list is not possible as terraform would destroy the last list item and not the exact deployment that was removed.
+`prod_deployment_id` - represents the list index of the deployment that the prod stage points to. The indexing starts from 0.
+
+Changes to the variables achieves a step from the AWS API Gateway deployment process like:
+
+1. Make changes in terraform to the API Gateway resources configuration.
+2. Add an item to the `api_deployments` list to create a new deployment.
+3. Change the value of `prod_deployment_id` to point to the index of new deployment in the `api_deployments` list.
+
+Steps can be done in one or several `terraform apply` runs.
+
 ## Running terraform
 
 * `terraform init` - initializes the terraform project directory.

--- a/terraform/aws-api-getaway/aws-api-gateway-input.tf
+++ b/terraform/aws-api-getaway/aws-api-gateway-input.tf
@@ -19,3 +19,14 @@ variable "lambda_invoke_arn" {
   description = "the lambda function invokation arn to use for the API gatway integration"
 }
 
+variable "api_deployments" {
+  type        = list
+  description = "a list representing deployments of the API. Every time an item is added a new deployment will be created. Do not remove items once created"
+  default     = ["v0.1.0"]
+}
+
+variable "prod_deployment_id" {
+  type        = number
+  description = "The index in the api_deployments list of the deployment to associate with the prod stage."
+  default     = 0
+}

--- a/terraform/aws-api-getaway/aws-api-gateway-main.tf
+++ b/terraform/aws-api-getaway/aws-api-gateway-main.tf
@@ -19,10 +19,16 @@ resource "aws_api_gateway_resource" "download" {
   path_part   = "download"
 }
 
-resource "aws_api_gateway_deployment" "prod" {
-  depends_on = [aws_api_gateway_integration.lambda_integration]
-
+resource "aws_api_gateway_deployment" "deployments" {
+  count       = length(var.api_deployments)
+  depends_on  = [aws_api_gateway_integration.lambda_integration]
+  description = var.api_deployments[count.index]
   rest_api_id = aws_api_gateway_rest_api.API.id
-  stage_name  = "prod"
+}
+
+resource "aws_api_gateway_stage" "prod" {
+  stage_name    = "prod"
+  rest_api_id   = aws_api_gateway_rest_api.API.id
+  deployment_id = aws_api_gateway_deployment.deployments[var.prod_deployment_id].id
 }
 

--- a/terraform/aws-api-getaway/aws-api-gateway-output.tf
+++ b/terraform/aws-api-getaway/aws-api-gateway-output.tf
@@ -1,8 +1,8 @@
 output "endpoint_prod" {
-  value = aws_api_gateway_deployment.prod.invoke_url
+  value = aws_api_gateway_stage.prod.invoke_url
 }
 
 output "download_url_prod" {
-  value = "${aws_api_gateway_deployment.prod.invoke_url}/download"
+  value = "${aws_api_gateway_stage.prod.invoke_url}/download"
 }
 

--- a/terraform/input.tf
+++ b/terraform/input.tf
@@ -9,6 +9,18 @@ variable "api_description" {
   description = "description of the API gateway"
 }
 
+variable "api_deployments" {
+  type        = list
+  description = "a list representing deployments of the API. Every time an item is added a new deployment will be created. Do not remove items once created!"
+  default     = ["v0.1.0"]
+}
+
+variable "prod_deployment_id" {
+  type        = number
+  description = "The index in the api_deployments list of the deployment to associate with the prod stage. Strats from 0."
+  default     = 0
+}
+
 variable "function_name" {
   type        = string
   default     = "hc-get-product"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,10 +5,12 @@ module "lambda_function" {
 }
 
 module "api_gateway" {
-  source            = "./aws-api-getaway/"
-  api_name          = var.api_name
-  api_description   = var.api_description
-  lambda_name       = module.lambda_function.function_name
-  lambda_invoke_arn = module.lambda_function.function_invoke_arn
+  source             = "./aws-api-getaway/"
+  api_name           = var.api_name
+  api_description    = var.api_description
+  lambda_name        = module.lambda_function.function_name
+  lambda_invoke_arn  = module.lambda_function.function_invoke_arn
+  prod_deployment_id = var.prod_deployment_id
+  api_deployments    = var.api_deployments
 }
 

--- a/terraform/test.tfvars
+++ b/terraform/test.tfvars
@@ -1,4 +1,6 @@
-api_name           = "hcbuilds-kitchen-test"
-function_name      = "get-hc-build-kitchen-test"
-function_code_file = "./lambda-get-hcproduct.zip"
-aws_region         = "us-east-2"
+api_name            = "hcbuilds-kitchen-test"
+function_name       = "get-hc-build-kitchen-test"
+function_code_file  = "./lambda-get-hcproduct.zip"
+aws_region          = "us-east-2"
+api_deployments = ["v0.1.0"]
+prod_deployment_id = 0


### PR DESCRIPTION
Change the terraform configuration so that it can follow the AWS intended process of API Gateway deployments:
1. Make changes to the API Gateway resources
2. Rollout the new API Gateway configuration as a deployment
3. Point one/more API Gateway stages to the new deployment